### PR TITLE
Create cli command for claiming github username

### DIFF
--- a/packages/cli/src/commands/account/claim-github.ts
+++ b/packages/cli/src/commands/account/claim-github.ts
@@ -1,0 +1,56 @@
+import { hashOfClaim, KeybaseClaim } from '@celo/contractkit/lib/identity/claims/claim'
+import {
+  createKeybaseClaim,
+  keybaseFilePathToProof,
+  proofFileName,
+  targetURL,
+} from '@celo/contractkit/lib/identity/claims/keybase'
+import { flags } from '@oclif/command'
+import { toChecksumAddress } from 'ethereumjs-util'
+import { writeFileSync } from 'fs'
+import { ClaimCommand } from '../../utils/identity'
+
+export default class ClaimGithub extends ClaimCommand {
+  static description = 'Claim a github username and add the claim to a local metadata file'
+  static flags = {
+    ...ClaimCommand.flags,
+    username: flags.string({
+      required: true,
+      description: 'The github username you want to claim',
+    }),
+  }
+  static args = ClaimCommand.args
+  static examples = [
+    'claim-github ~/metadata.json --from 0x47e172F6CfB6c7D01C1574fa3E2Be7CC73269D95 --username myusername',
+  ]
+  self = ClaimGithub
+
+  async run() {
+    const res = this.parse(ClaimGithub)
+    const username = res.flags.username
+    const metadata = await this.readMetadata()
+    const accountAddress = toChecksumAddress(metadata.data.meta.address)
+    const claim = createKeybaseClaim(username)
+    const signature = await this.signer.sign(hashOfClaim(claim))
+    await this.addClaim(metadata, claim)
+    this.writeMetadata(metadata)
+
+    this.printManualInstruction(claim, signature, username, accountAddress)
+  }
+
+  printManualInstruction(
+    claim: KeybaseClaim,
+    signature: string,
+    username: string,
+    address: string
+  ) {
+    const fileName = proofFileName(address)
+    writeFileSync(fileName, JSON.stringify({ claim, signature }))
+    console.info(
+      `\nProving a github claim requires you to publish the signed claim on your Github account to prove ownership. We saved it for you under ${fileName}. It should be hosted in your public folder at ${keybaseFilePathToProof}/${fileName}, so that it is available under ${targetURL(
+        username,
+        address
+      )}\n`
+    )
+  }
+}

--- a/packages/cli/src/commands/account/claim-github.ts
+++ b/packages/cli/src/commands/account/claim-github.ts
@@ -37,7 +37,7 @@ export default class ClaimGithub extends ClaimCommand {
     const fileName = proofFileName(address)
     writeFileSync(fileName, JSON.stringify({ claim, signature }))
     console.info(
-      `\nProving a github claim requires you to publish the signed claim on your Github account to prove ownership. We saved it for you under ${fileName}. Please create a public gist with this one file, using your Github account ${username}.\n`
+      `\nProving a github claim requires you to publish the signed claim on your Github account to prove ownership. We saved it for you under ${fileName}. Please create a public repository called "celo-metadata" with this file in it, using your Github account ${username}.\n`
     )
   }
 }

--- a/packages/cli/src/commands/account/claim-github.ts
+++ b/packages/cli/src/commands/account/claim-github.ts
@@ -1,10 +1,5 @@
-import { hashOfClaim, KeybaseClaim } from '@celo/contractkit/lib/identity/claims/claim'
-import {
-  createKeybaseClaim,
-  keybaseFilePathToProof,
-  proofFileName,
-  targetURL,
-} from '@celo/contractkit/lib/identity/claims/keybase'
+import { GithubClaim, hashOfClaim } from '@celo/contractkit/lib/identity/claims/claim'
+import { createGithubClaim, proofFileName } from '@celo/contractkit/lib/identity/claims/github'
 import { flags } from '@oclif/command'
 import { toChecksumAddress } from 'ethereumjs-util'
 import { writeFileSync } from 'fs'
@@ -30,7 +25,7 @@ export default class ClaimGithub extends ClaimCommand {
     const username = res.flags.username
     const metadata = await this.readMetadata()
     const accountAddress = toChecksumAddress(metadata.data.meta.address)
-    const claim = createKeybaseClaim(username)
+    const claim = createGithubClaim(username)
     const signature = await this.signer.sign(hashOfClaim(claim))
     await this.addClaim(metadata, claim)
     this.writeMetadata(metadata)
@@ -38,19 +33,11 @@ export default class ClaimGithub extends ClaimCommand {
     this.printManualInstruction(claim, signature, username, accountAddress)
   }
 
-  printManualInstruction(
-    claim: KeybaseClaim,
-    signature: string,
-    username: string,
-    address: string
-  ) {
+  printManualInstruction(claim: GithubClaim, signature: string, username: string, address: string) {
     const fileName = proofFileName(address)
     writeFileSync(fileName, JSON.stringify({ claim, signature }))
     console.info(
-      `\nProving a github claim requires you to publish the signed claim on your Github account to prove ownership. We saved it for you under ${fileName}. It should be hosted in your public folder at ${keybaseFilePathToProof}/${fileName}, so that it is available under ${targetURL(
-        username,
-        address
-      )}\n`
+      `\nProving a github claim requires you to publish the signed claim on your Github account to prove ownership. We saved it for you under ${fileName}. Please create a public gist with this one file, using your Github account ${username}.\n`
     )
   }
 }

--- a/packages/cli/src/commands/transfer/dollars.ts
+++ b/packages/cli/src/commands/transfer/dollars.ts
@@ -14,6 +14,10 @@ export default class TransferDollars extends BaseCommand {
     to: Flags.address({ required: true, description: 'Address of the receiver' }),
     value: flags.string({ required: true, description: 'Amount to transfer (in wei)' }),
     comment: flags.string({ description: 'Transfer comment' }),
+    approve: flags.boolean({
+      description: 'Whether to approve instead of transfer',
+      default: false,
+    }),
   }
 
   static examples = [
@@ -31,6 +35,8 @@ export default class TransferDollars extends BaseCommand {
 
     const tx = res.flags.comment
       ? stableToken.transferWithComment(to, value.toFixed(), res.flags.comment)
+      : res.flags.approve
+      ? stableToken.approve(to, value.toFixed())
       : stableToken.transfer(to, value.toFixed())
 
     await newCheckBuilder(this)
@@ -53,6 +59,9 @@ export default class TransferDollars extends BaseCommand {
       )
       .runChecks()
 
-    await displaySendTx(res.flags.comment ? 'transferWithComment' : 'transfer', tx)
+    await displaySendTx(
+      res.flags.comment ? 'transferWithComment' : res.flags.approve ? 'approve' : 'transfer',
+      tx
+    )
   }
 }

--- a/packages/contractkit/src/identity/claims/claim.ts
+++ b/packages/contractkit/src/identity/claims/claim.ts
@@ -17,6 +17,14 @@ export const KeybaseClaimType = t.type({
 })
 export type KeybaseClaim = t.TypeOf<typeof KeybaseClaimType>
 
+export const GithubClaimType = t.type({
+  type: t.literal(ClaimTypes.GITHUB),
+  timestamp: TimestampType,
+  // TODO: Validate compliant username before just interpolating
+  username: t.string,
+})
+export type GithubClaim = t.TypeOf<typeof GithubClaimType>
+
 const DomainClaimType = t.type({
   type: t.literal(ClaimTypes.DOMAIN),
   timestamp: TimestampType,
@@ -61,6 +69,7 @@ export type Claim =
   | NameClaim
   | AccountClaim
   | StorageClaim
+  | GithubClaim
 
 export type ClaimPayload<K extends ClaimTypes> = K extends typeof ClaimTypes.DOMAIN
   ? DomainClaim

--- a/packages/contractkit/src/identity/claims/claim.ts
+++ b/packages/contractkit/src/identity/claims/claim.ts
@@ -82,7 +82,9 @@ export type ClaimPayload<K extends ClaimTypes> = K extends typeof ClaimTypes.DOM
   ? AttestationServiceURLClaim
   : K extends typeof ClaimTypes.ACCOUNT
   ? AccountClaim
-  : StorageClaim
+  : K extends typeof ClaimTypes.STORAGE
+  ? StorageClaim
+  : GithubClaim
 
 export const isOfType = <K extends ClaimTypes>(type: K) => (data: Claim): data is ClaimPayload<K> =>
   data.type === type

--- a/packages/contractkit/src/identity/claims/claim.ts
+++ b/packages/contractkit/src/identity/claims/claim.ts
@@ -51,6 +51,7 @@ export const ClaimType = t.union([
   KeybaseClaimType,
   NameClaimType,
   StorageClaimType,
+  GithubClaimType,
 ])
 
 export const SignedClaimType = t.type({

--- a/packages/contractkit/src/identity/claims/github.ts
+++ b/packages/contractkit/src/identity/claims/github.ts
@@ -1,0 +1,72 @@
+import { Address } from '@celo/base/lib/address'
+import fetch from 'cross-fetch'
+import { isLeft } from 'fp-ts/lib/Either'
+import { ContractKit } from '../../kit'
+import { IdentityMetadataWrapper } from '../metadata'
+import { GithubClaim, GithubClaimType, hashOfClaim, SignedClaimType } from './claim'
+import { ClaimTypes, now } from './types'
+
+export const proofFileName = (address: Address) => `verify-${address}.json`
+export const gistsURL = (username: string) => `https://api.github.com/users/${username}/gists`
+
+// If verification encounters an error, returns the error message as a string
+// otherwise returns undefined when successful
+export async function verifyGithubClaim(
+  kit: ContractKit,
+  username: string,
+  signer: Address
+): Promise<string | undefined> {
+  try {
+    const resp = await fetch(gistsURL(username))
+    if (!resp.ok) {
+      return `Proof of ownership could not be retrieved at ${gistsURL(username)}, request yielded ${
+        resp.status
+      } status code`
+    }
+
+    const jsonResp = await resp.json()
+    const claimObj = jsonResp.find((gist: any) => gist.files.hasOwnProperty(proofFileName))
+    if (!claimObj) {
+      return `Proof of ownership does not exist in ${username}'s gists.`
+    }
+
+    const claimURL = claimObj.url
+    const claimResp = await fetch(claimURL)
+    const claimJsonResp = await claimResp.json()
+
+    const parsedClaim = SignedClaimType.decode(claimJsonResp)
+    if (isLeft(parsedClaim)) {
+      return 'Claim is incorrectly formatted'
+    }
+
+    const hasValidSignature = await IdentityMetadataWrapper.verifySignerForAddress(
+      kit,
+      hashOfClaim(parsedClaim.right.claim),
+      parsedClaim.right.signature,
+      signer
+    )
+
+    if (!hasValidSignature) {
+      return 'Claim does not contain a valid signature'
+    }
+
+    const parsedGithubClaim = GithubClaimType.decode(parsedClaim.right.claim)
+    if (isLeft(parsedGithubClaim)) {
+      return 'Hosted claim is not a Github claim'
+    }
+
+    if (parsedGithubClaim.right.username !== username) {
+      return 'Usernames do not match'
+    }
+
+    return
+  } catch (error) {
+    return 'Could not verify Github claim: ' + error
+  }
+}
+
+export const createGithubClaim = (username: string): GithubClaim => ({
+  username,
+  timestamp: now(),
+  type: ClaimTypes.GITHUB,
+})

--- a/packages/contractkit/src/identity/claims/types.ts
+++ b/packages/contractkit/src/identity/claims/types.ts
@@ -14,9 +14,15 @@ export enum ClaimTypes {
   PROFILE_PICTURE = 'PROFILE_PICTURE',
   STORAGE = 'STORAGE',
   TWITTER = 'TWITTER',
+  GITHUB = 'GITHUB',
 }
 
-export const VERIFIABLE_CLAIM_TYPES = [ClaimTypes.KEYBASE, ClaimTypes.ACCOUNT, ClaimTypes.DOMAIN]
+export const VERIFIABLE_CLAIM_TYPES = [
+  ClaimTypes.KEYBASE,
+  ClaimTypes.ACCOUNT,
+  ClaimTypes.DOMAIN,
+  ClaimTypes.GITHUB,
+]
 
 // Claims whose status can be validated
 export const VALIDATABLE_CLAIM_TYPES = [ClaimTypes.ATTESTATION_SERVICE_URL]

--- a/packages/contractkit/src/identity/claims/verify.ts
+++ b/packages/contractkit/src/identity/claims/verify.ts
@@ -5,7 +5,8 @@ import { promisify } from 'util'
 import { ContractKit } from '../..'
 import { IdentityMetadataWrapper } from '../metadata'
 import { AccountClaim } from './account'
-import { Claim, DOMAIN_TXT_HEADER, DomainClaim, serializeClaim } from './claim'
+import { Claim, DomainClaim, DOMAIN_TXT_HEADER, serializeClaim } from './claim'
+import { verifyGithubClaim } from './github'
 import { verifyKeybaseClaim } from './keybase'
 import { ClaimTypes } from './types'
 
@@ -24,6 +25,8 @@ export async function verifyClaim(kit: ContractKit, claim: Claim, address: strin
       return verifyAccountClaim(kit, claim, address)
     case ClaimTypes.DOMAIN:
       return verifyDomainRecord(kit, claim, address)
+    case ClaimTypes.GITHUB:
+      return verifyGithubClaim(kit, claim.username, address)
     default:
       break
   }


### PR DESCRIPTION
### Description
 
`account:claim-github` requires from the user a `metadata.json` file, their account address, and their github username, and generates a json with a signature that is to be uploaded onto the user's github.

### Tested

not tested, needs variable names from `github.ts` in contractKit

### Related issues

- Fixes #[issue number here]
